### PR TITLE
fix(synthetic): drop setup_entities() from atomarray_to_gemmi so written cifs round-trip chain_info

### DIFF
--- a/scripts/eval/rscc_grid_search_script.py
+++ b/scripts/eval/rscc_grid_search_script.py
@@ -31,7 +31,6 @@ import pandas as pd
 import torch
 
 # Import local modules for density calculation
-from atomworks.io.parser import parse
 from joblib import delayed, Parallel
 from loguru import logger
 from sampleworks.eval.constants import DEFAULT_SELECTION_PADDING
@@ -44,6 +43,7 @@ from sampleworks.eval.structure_utils import (
 )
 from sampleworks.utils.atom_array_utils import (
     filter_to_common_atoms,
+    parse_structure,
     remove_atoms_with_any_nan_coords,
 )
 from sampleworks.utils.density_utils import (
@@ -133,10 +133,8 @@ def process_group(
             raise ValueError(
                 f"Could not find reference structure for occupancy {trials[0].altloc_occupancies}"
             )
-        # parse() returns only the first altloc.
-        ref_structure = parse(
-            ref_path, ccd_mirror_path=None, add_missing_atoms=False, hydrogen_policy="remove"
-        )
+        # parse_structure() returns only the first altloc.
+        ref_structure = parse_structure(ref_path)
         ref_atom_array = get_asym_unit_from_structure(ref_structure)
         ref_atom_array = remove_atoms_with_any_nan_coords(ref_atom_array)
     except (FileNotFoundError, OSError, ValueError, RuntimeError, AttributeError, TypeError) as e:
@@ -159,12 +157,7 @@ def process_group(
     # parse refined, align, and compute density once per trial.
     for trial in trials:
         try:
-            structure = parse(
-                trial.refined_cif_path,
-                ccd_mirror_path=None,
-                add_missing_atoms=False,
-                hydrogen_policy="remove",
-            )
+            structure = parse_structure(trial.refined_cif_path)
             atom_array = get_asym_unit_from_structure(structure)
             if not hasattr(atom_array, "coord") or atom_array.coord is None:
                 raise AttributeError("AtomArray | AtomArrayStack is missing coordinates")

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -393,6 +393,12 @@ def atomarray_to_gemmi(
     the atom array has no ``altloc_id`` annotation (e.g. arrays reconstructed by
     a model wrapper), all altlocs default to blank.
 
+    No entities are assigned, so a cif written from the result has no entity block
+    and ``_atom_site.label_entity_id`` is ``.``. Sequences are then inferred from
+    ``_atom_site`` on reload, which is what model wrappers need; the cost is that
+    ``chain_info`` loses ``rcsb_entity`` (only Protenix reads it, and it falls back
+    to the chain id).
+
     Parameters
     ----------
     atom_array
@@ -408,14 +414,6 @@ def atomarray_to_gemmi(
     -------
     gemmi.Structure
         Structure ready to be wrapped by SFC_Torch.io.PDBParser
-
-    Notes
-    -----
-    No entities are assigned, so a cif written from the result has no entity block
-    and ``_atom_site.label_entity_id`` is ``.``. Sequences are then inferred from
-    ``_atom_site`` on reload, which is what model wrappers need; the cost is that
-    ``chain_info`` loses ``rcsb_entity`` (only Protenix reads it, and it falls back
-    to the chain id).
     """
     if len(atom_array) == 0:
         raise ValueError("Cannot convert an empty AtomArray to a gemmi.Structure.")

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -362,8 +362,9 @@ def _build_gemmi_residue(
     residue.name = atom_array.res_name[start_idx]
     residue.seqid = gemmi.SeqId(str(res_id))  # writes auth_seq_id
     residue.label_seq = res_id  # writes label_seq_id, important for saving mmCIF
-    # if the subchain id is not set, gemmi's setup_entities() will set it to multi-char,
-    # which is rejected by SFcalculator's PDB-header step.
+    # writes label_asym_id; nothing else assigns it, since atomarray_to_gemmi
+    # deliberately skips setup_entities(). Must stay single-char -- SFcalculator's
+    # PDB-header step rejects the multi-char subchain ids setup_entities() invents.
     residue.subchain = atom_array.chain_id[start_idx]
     # biotite's bool `hetero` -> gemmi's single-char het_flag ('H' HETATM / 'A' ATOM)
     residue.het_flag = "H" if bool(atom_array.hetero[start_idx]) else "A"
@@ -407,6 +408,14 @@ def atomarray_to_gemmi(
     -------
     gemmi.Structure
         Structure ready to be wrapped by SFC_Torch.io.PDBParser
+
+    Notes
+    -----
+    No entities are assigned, so a cif written from the result has no entity block
+    and ``_atom_site.label_entity_id`` is ``.``. Sequences are then inferred from
+    ``_atom_site`` on reload, which is what model wrappers need; the cost is that
+    ``chain_info`` loses ``rcsb_entity`` (only Protenix reads it, and it falls back
+    to the chain id).
     """
     if len(atom_array) == 0:
         raise ValueError("Cannot convert an empty AtomArray to a gemmi.Structure.")
@@ -429,7 +438,11 @@ def atomarray_to_gemmi(
 
     structure = gemmi.Structure()
     structure.add_model(model)
-    structure.setup_entities()  # SFcalculator/PDBParser expects entities assigned
+    # No setup_entities(): it fabricates entities with an empty full_sequence, so the
+    # written cif carries _entity/_entity_poly but no _entity_poly_seq. Atomworks reads
+    # this partial block which leads to KeyError when model wrapper accessing fields like
+    # `processed_entity_canonical_sequence`. When there are no entities, gemmi writes no
+    # entity block and atomworks infers the sequence from _atom_site instead.
     if unit_cell is not None:
         structure.cell = unit_cell
     if space_group is not None:

--- a/src/sampleworks/utils/atom_array_utils.py
+++ b/src/sampleworks/utils/atom_array_utils.py
@@ -6,6 +6,7 @@ from typing import Any, cast, Literal, overload
 
 import einx
 import numpy as np
+from atomworks import parse
 from atomworks.io.transforms.atom_array import ensure_atom_array_stack
 from atomworks.io.utils.io_utils import load_any
 from biotite.structure import AtomArray, AtomArrayStack, filter_amino_acids, filter_polymer, stack
@@ -130,6 +131,29 @@ def get_mask_from_old_selection_string(
     if mask.sum() == 0:
         raise ValueError(f"Selection '{selection}' matched no atoms")
     return mask
+
+
+def parse_structure(path: str | Path) -> dict[str, Any]:
+    """Parse a structure with the options used by Sampleworks production kwargs in
+    guidance.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to a PDB or mmCIF structure file.
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed Atomworks structure and metadata, including ``"asym_unit"`` and
+        ``"chain_info"``.
+    """
+    return parse(
+        Path(path),
+        hydrogen_policy="remove",
+        add_missing_atoms=False,
+        ccd_mirror_path=None,
+    )
 
 
 def load_structure_with_altlocs(path: Path) -> AtomArray:

--- a/src/sampleworks/utils/guidance_script_utils.py
+++ b/src/sampleworks/utils/guidance_script_utils.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import numpy as np
 import torch
-from atomworks import parse
 from atomworks.io.transforms.atom_array import ensure_atom_array_stack
 from biotite.structure import AtomArray, AtomArrayStack, stack
 from biotite.structure.io import save_structure
@@ -31,6 +30,7 @@ from sampleworks.core.scalers.step_scalers import (
     NoScalingScaler,
 )
 from sampleworks.eval.occupancy_utils import extract_protein_and_occupancy
+from sampleworks.utils.atom_array_utils import parse_structure
 from sampleworks.utils.cif_utils import add_category_to_cif, resolve_mixed_hetatm_atom_altlocs
 from sampleworks.utils.guidance_constants import (
     GuidanceType,
@@ -276,12 +276,7 @@ def get_reward_function_and_structure(
     """Load structure and density inputs and build the real-space reward function."""
     logger.debug(f"Loading structure from {structure_path}")
     safe_structure_path = resolve_mixed_hetatm_atom_altlocs(Path(structure_path))
-    structure = parse(
-        safe_structure_path,
-        hydrogen_policy="remove",
-        add_missing_atoms=False,
-        ccd_mirror_path=None,
-    )
+    structure = parse_structure(safe_structure_path)
 
     # make sure to cast paths to strings, since Path(x) != str(x) we don't want to
     # accidentally delete the originals.

--- a/tests/eval/test_rscc_grid_search_script.py
+++ b/tests/eval/test_rscc_grid_search_script.py
@@ -82,18 +82,18 @@ def test_main_end_to_end_produces_csv(rscc_fixture_factory, rscc_script):
 @pytest.mark.slow
 def test_trial_parse_failure_emits_error_rows(rscc_fixture_factory, rscc_script, monkeypatch):
     """
-    Trial level ``parse`` failure results in one NaN-RSCC row per valid selection.
+    Trial-level structure parsing failure results in one NaN-RSCC row per valid selection.
     """
     fx = rscc_fixture_factory(n_groups=1, trials_per_group=1)
 
-    real_parse = rscc_script.parse
+    real_parse_structure = rscc_script.parse_structure
 
-    def flaky_parse(path, ccd_mirror_path=None):
+    def flaky_parse_structure(path):
         if "refined" in str(path):
             raise RuntimeError("simulated trial parse failure")
-        return real_parse(path, ccd_mirror_path=ccd_mirror_path)
+        return real_parse_structure(path)
 
-    monkeypatch.setattr(rscc_script, "parse", flaky_parse)
+    monkeypatch.setattr(rscc_script, "parse_structure", flaky_parse_structure)
 
     rscc_script.main(fx)
 

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -41,7 +41,19 @@ CROSS_MODEL_CHAIN_INFO_KEYS = ("chain_type", "processed_entity_canonical_sequenc
 
 
 def _parse_at_production_kwargs(path: Path) -> dict:
-    """Parse a structure with the kwargs ``run_guidance`` uses."""
+    """Parse a structure with the kwargs ``run_guidance`` uses.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the structure file to parse.
+
+    Returns
+    -------
+    dict
+        The parsed Atomworks structure, keyed by ``"asym_unit"``, ``"chain_info"``, and the
+        rest of the parse metadata.
+    """
     return parse(path, hydrogen_policy="remove", add_missing_atoms=False, ccd_mirror_path=None)
 
 
@@ -241,13 +253,13 @@ class TestAtomArrayToGemmi:
         The load_any test above covers _atom_site fidelity. This one covers the layer above
         it: atomworks derives chain_info from the entity block when one is present and from
         _atom_site when it is not. Emitting a partial entity block (an _entity/_entity_poly
-        with no _entity_poly_seq, which gemmi's setup_entities() produces) puts atomworks on
-        the first path with nothing to read, so chain_info comes back carrying
+        with no _entity_poly_seq, which gemmi's setup_entities() would produce) leads to the
+        first path with nothing to read, so chain_info comes back carrying
         unprocessed_entity_canonical_sequence and every wrapper that reads
         processed_entity_canonical_sequence raises KeyError.
         """
         source = _parse_at_production_kwargs(resources_dir / "6b8x" / "6b8x_final.pdb")
-        ref = get_asym_unit_from_structure(source, 0)  # parse returns a stack; take model 0
+        ref = get_asym_unit_from_structure(source, 0)  # parse returns a stack; take the first model
 
         save_cif_path = tmp_path / "saved.cif"
         gemmi_structure = atomarray_to_gemmi(ref, stripped_gemmi.cell, stripped_gemmi.spacegroup_hm)
@@ -265,12 +277,16 @@ class TestAtomArrayToGemmi:
                     f"chain {chain_id} field {key!r} did not round-trip"
                 )
 
-        # chain_info only means something if the same atoms came back: parse's processing
-        # (altloc resolution, chain splitting, hydrogen policy) can drop or renumber atoms
-        # without disturbing the sequence.
+        # The canonical sequence is per-residue, but parse's processing could drop or renumber
+        # atoms without disturbing the sequence. Here we check that on a per-atom level the
+        # identity is preserved. Other annotation fields (b_factor/occupancy/element) are checked
+        # in the annotations round-trip test above.
         loaded = get_asym_unit_from_structure(written, 0)
         assert len(loaded) == len(ref)
-        assert np.array_equal(loaded.res_id, ref.res_id)
+        for category in ("chain_id", "res_id", "atom_name"):
+            assert np.array_equal(loaded.get_annotation(category), ref.get_annotation(category)), (
+                f"annotation {category!r} did not survive the parse round-trip"
+            )
 
     def test_multichain_shared_res_ids_not_merged_in_gemmi(self, multichain_shared_resid_array):
         """Test that atomarray_to_gemmi splits shared res_ids into separate residues per chain

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -9,9 +9,11 @@ import numpy as np
 import pytest
 import reciprocalspaceship as rs
 import torch
+from atomworks import parse
 from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
 from reciprocalspaceship.dtypes.base import MTZDtype
+from sampleworks.eval.structure_utils import get_asym_unit_from_structure
 from sampleworks.synthetic.synthetic_utils import (
     assign_occupancies,
     atomarray_to_gemmi,
@@ -32,6 +34,15 @@ from SFC_Torch.utils import assert_numpy
 
 
 DMIN = 2.0
+
+# chain_info fields the model wrappers read: chain_type (all), the canonical sequence
+# (Boltz/Protpardelle polymer YAML), and res_name (Boltz ligand CCD code).
+CROSS_MODEL_CHAIN_INFO_KEYS = ("chain_type", "processed_entity_canonical_sequence", "res_name")
+
+
+def _parse_at_production_kwargs(path: Path) -> dict:
+    """Parse a structure with the kwargs ``run_guidance`` uses."""
+    return parse(path, hydrogen_policy="remove", add_missing_atoms=False, ccd_mirror_path=None)
 
 
 @pytest.fixture(scope="module")
@@ -222,6 +233,44 @@ class TestAtomArrayToGemmi:
         np.testing.assert_allclose(loaded.coord, ref.coord, atol=1e-3)
         np.testing.assert_allclose(loaded.b_factor, ref.b_factor, atol=1e-2)
         np.testing.assert_allclose(loaded.occupancy, ref.occupancy, atol=1e-2)
+
+    def test_saved_structure_round_trips_chain_info(self, resources_dir, stripped_gemmi, tmp_path):
+        """Test that a cif written by atomarray_to_gemmi parses back to the same chain_info
+        the source file does, so generated cifs can feed model featurization.
+
+        The load_any test above covers _atom_site fidelity. This one covers the layer above
+        it: atomworks derives chain_info from the entity block when one is present and from
+        _atom_site when it is not. Emitting a partial entity block (an _entity/_entity_poly
+        with no _entity_poly_seq, which gemmi's setup_entities() produces) puts atomworks on
+        the first path with nothing to read, so chain_info comes back carrying
+        unprocessed_entity_canonical_sequence and every wrapper that reads
+        processed_entity_canonical_sequence raises KeyError.
+        """
+        source = _parse_at_production_kwargs(resources_dir / "6b8x" / "6b8x_final.pdb")
+        ref = get_asym_unit_from_structure(source, 0)  # parse returns a stack; take model 0
+
+        save_cif_path = tmp_path / "saved.cif"
+        gemmi_structure = atomarray_to_gemmi(ref, stripped_gemmi.cell, stripped_gemmi.spacegroup_hm)
+        gemmi_structure.make_mmcif_document().write_file(str(save_cif_path))
+        written = _parse_at_production_kwargs(save_cif_path)
+
+        source_info, written_info = source["chain_info"], written["chain_info"]
+        assert set(written_info) == set(source_info)
+        for chain_id, expected in source_info.items():
+            actual = written_info[chain_id]
+            for key in CROSS_MODEL_CHAIN_INFO_KEYS:
+                assert key in expected, f"source chain {chain_id} has no {key!r}"
+                assert key in actual, f"round-tripped chain {chain_id} lost {key!r}"
+                assert np.array_equal(np.asarray(actual[key]), np.asarray(expected[key])), (
+                    f"chain {chain_id} field {key!r} did not round-trip"
+                )
+
+        # chain_info only means something if the same atoms came back: parse's processing
+        # (altloc resolution, chain splitting, hydrogen policy) can drop or renumber atoms
+        # without disturbing the sequence.
+        loaded = get_asym_unit_from_structure(written, 0)
+        assert len(loaded) == len(ref)
+        assert np.array_equal(loaded.res_id, ref.res_id)
 
     def test_multichain_shared_res_ids_not_merged_in_gemmi(self, multichain_shared_resid_array):
         """Test that atomarray_to_gemmi splits shared res_ids into separate residues per chain

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 import reciprocalspaceship as rs
 import torch
-from atomworks import parse
 from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
 from reciprocalspaceship.dtypes.base import MTZDtype
@@ -26,6 +25,7 @@ from sampleworks.utils.atom_array_utils import (
     keep_amino_acids,
     keep_polymer,
     load_structure_with_altlocs,
+    parse_structure,
     remove_hydrogens,
 )
 from SFC_Torch import SFcalculator
@@ -38,23 +38,6 @@ DMIN = 2.0
 # chain_info fields the model wrappers read: chain_type (all), the canonical sequence
 # (Boltz/Protpardelle polymer YAML), and res_name (Boltz ligand CCD code).
 CROSS_MODEL_CHAIN_INFO_KEYS = ("chain_type", "processed_entity_canonical_sequence", "res_name")
-
-
-def _parse_at_production_kwargs(path: Path) -> dict:
-    """Parse a structure with the kwargs ``run_guidance`` uses.
-
-    Parameters
-    ----------
-    path : Path
-        Path to the structure file to parse.
-
-    Returns
-    -------
-    dict
-        The parsed Atomworks structure, keyed by ``"asym_unit"``, ``"chain_info"``, and the
-        rest of the parse metadata.
-    """
-    return parse(path, hydrogen_policy="remove", add_missing_atoms=False, ccd_mirror_path=None)
 
 
 @pytest.fixture(scope="module")
@@ -258,13 +241,13 @@ class TestAtomArrayToGemmi:
         unprocessed_entity_canonical_sequence and every wrapper that reads
         processed_entity_canonical_sequence raises KeyError.
         """
-        source = _parse_at_production_kwargs(resources_dir / "6b8x" / "6b8x_final.pdb")
+        source = parse_structure(resources_dir / "6b8x" / "6b8x_final.pdb")
         ref = get_asym_unit_from_structure(source, 0)  # parse returns a stack; take the first model
 
         save_cif_path = tmp_path / "saved.cif"
         gemmi_structure = atomarray_to_gemmi(ref, stripped_gemmi.cell, stripped_gemmi.spacegroup_hm)
         gemmi_structure.make_mmcif_document().write_file(str(save_cif_path))
-        written = _parse_at_production_kwargs(save_cif_path)
+        written = parse_structure(save_cif_path)
 
         source_info, written_info = source["chain_info"], written["chain_info"]
         assert set(written_info) == set(source_info)

--- a/tests/utils/test_guidance_script_utils.py
+++ b/tests/utils/test_guidance_script_utils.py
@@ -114,7 +114,7 @@ def test_get_reward_function_keeps_original_structure_file(
         lambda path: Path(path),
     )
     monkeypatch.setattr(
-        "sampleworks.utils.guidance_script_utils.parse",
+        "sampleworks.utils.guidance_script_utils.parse_structure",
         lambda *args, **kwargs: {
             "asym_unit": build_test_atom_array(n_atoms=3, with_occupancy=True)
         },


### PR DESCRIPTION
## What

`atomarray_to_gemmi()` called `structure.setup_entities()` before writing. That fabricates entities with an empty `full_sequence`, so the written cif carries `_entity` / `_entity_poly` but no `_entity_poly_seq`. Atomworks reads that partial block and then raises `KeyError` in model wrappers accessing fields like `processed_entity_canonical_sequence`.

Dropping the call means gemmi writes no entity block at all, and atomworks infers the sequence from `_atom_site` instead — which is what the model wrappers need.


Also refactored `parse_structure` function in `atom_array_utils.py` to more consistently reuse production kwagrs for `parse`:
```
hydrogen_policy="remove",
add_missing_atoms=False,
ccd_mirror_path=None,
```
A few call sites are affected: `guidance_script_utils.py` and `rscc_grid_search_script.py`.

## Cost

`chain_info` loses `rcsb_entity`. Only Protenix reads it, and it falls back to the chain id.

`residue.subchain` now carries the sole assignment of `label_asym_id` (nothing else sets it once `setup_entities()` is gone), so it must stay single-char — SFcalculator's PDB-header step rejects the multi-char subchain ids `setup_entities()` invents. Comment updated at the assignment site to say so.

## Tests

Adds round-trip coverage in `tests/synthetic/test_generate_synthetic_sf.py` asserting the written cif reloads with intact `chain_info`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mmCIF output to preserve single-character subchain IDs.
  * Prevented incomplete or fabricated entity metadata from being written.
  * Preserved chain metadata, atom identity, residue names, sequences, counts, and IDs when structures are saved and reloaded.

* **Tests**
  * Added coverage verifying metadata and atom identity survive mmCIF round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->