### PR TITLE
fix(astera): restore pixi cache image build

### DIFF
--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -57,7 +57,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # that the download cache no longer survives a pod restart — environments
 # themselves live in the synced checkout and are unaffected.
 RUN mkdir -p /var/cache/pixi
-    SAMPLEWORKS_SKIP_ENV_PREPARE=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \


### PR DESCRIPTION
## Summary
Restore the Astera image build after #369.

## Impact
Allows the pixi cache fix to publish to Harbor.

## Changes
- `Dockerfile.astera:60` removes the orphaned instruction that Docker treated as invalid.

## Testing
- `git diff --check`
- Docker source-check CI will run on this PR.

## Deployment
Merge rebuilds the image; then pin its digest in the actl catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Astera container setup so environment preparation is no longer skipped by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->