### PR TITLE
refactor(synthetic): relocate density generation

### DIFF
--- a/src/sampleworks/synthetic/generate_synthetic_density.py
+++ b/src/sampleworks/synthetic/generate_synthetic_density.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 
 import torch
 from loguru import logger
+
 from sampleworks.core.forward_models.xray.real_space_density import XMap_torch
 from sampleworks.synthetic.synthetic_utils import (
     load_structure_for_synthetic_reward,

--- a/tests/synthetic/test_generate_synthetic_density.py
+++ b/tests/synthetic/test_generate_synthetic_density.py
@@ -1,7 +1,7 @@
 """Tests for synthetic density batch-row argument handling."""
 
 import pytest
-from sampleworks.eval.generate_synthetic_density import BatchRow
+from sampleworks.synthetic.generate_synthetic_density import BatchRow
 
 
 def test_batch_row_accepts_occupancy_values_column() -> None:


### PR DESCRIPTION
## Summary
Fixes #346. Move synthetic density generation beside synthetic structure-factor generation.

## Impact
Synthetic generators now share one package; no callers use the old path.

## Changes
- `src/sampleworks/synthetic/generate_synthetic_density.py:1` relocates the generator.
- `tests/synthetic/test_generate_synthetic_density.py:4` updates its import.

## Testing
- `pixi run -e boltz-osx pytest tests/synthetic/test_generate_synthetic_density.py`
- Ruff check passed.

## Deployment
None.