### PR TITLE
test(runs): harden RF3 argv generation

### DIFF
--- a/tests/runs/test_runner.py
+++ b/tests/runs/test_runner.py
@@ -13,6 +13,7 @@ from sampleworks.runs.schema import Job
 def test_argv_for_rf3_partial_matches_bash(monkeypatch: pytest.MonkeyPatch) -> None:
     """RF3 partial builds the canonical argv and auto-assigns all GPUs."""
     monkeypatch.setenv("HOME", "/home/test")
+    monkeypatch.setenv("SAMPLEWORKS_FORCE_PIXI", "1")
     monkeypatch.delenv("DATA_DIR", raising=False)
     monkeypatch.delenv("RESULTS_DIR", raising=False)
     monkeypatch.setattr(runner, "_detect_available_gpus", lambda: [str(i) for i in range(8)])


### PR DESCRIPTION
## Summary
Fixes #287. Force the intended pixi path in the RF3 argv test.

## Impact
The test is deterministic on machines with baked environments.

## Changes
- `tests/runs/test_runner.py:16` sets `SAMPLEWORKS_FORCE_PIXI`.

## Testing
- `python3 -m py_compile tests/runs/test_runner.py`
- Focused pytest requires the project pixi environment.

## Deployment
None.