### PR TITLE
feat: move dev dependencies to a pixi feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,28 @@ analysis = [
   "scikit-learn",
   "seaborn"
 ]
-dev = ["pytest", "pytest-cov", "mypy", "prek", "ty==0.0.39", "ruff", "pytest-loguru", "python-semantic-release"]
 test = ["pytest", "pytest-cov", "pytest-loguru"]
 
+[tool.pixi.feature.dev]
+platforms = ["linux-64", "osx-arm64"]
+
+[tool.pixi.feature.dev.pypi-dependencies]
+pytest = "*"
+pytest-cov = "*"
+mypy = "*"
+prek = "*"
+ty = "==0.0.39"
+ruff = "*"
+pytest-loguru = "*"
+python-semantic-release = "*"
+
+
 [tool.pixi.feature.boltz]
-pypi-dependencies = {"boltz" = "*", "cuequivariance-torch" = "*", "cuequivariance-ops-torch-cu12" = "*", "rdkit" = ">=2025.3.6"}
+pypi-dependencies = {"boltz" = "==2.2.1", "cuequivariance-torch" = "*", "cuequivariance-ops-torch-cu12" = "*", "rdkit" = ">=2025.3.6"}
 platforms = ["linux-64"]
+
+[tool.pixi.feature.boltz.pypi-options.dependency-overrides]
+click = "==8.1.7"
 
 [tool.pixi.feature.boltz-osx]
 pypi-dependencies = {"boltz" = "*", "cuequivariance-torch" = "*", "rdkit" = ">=2025.3.6", "joblib" = "*", "sfcalculator-torch" = ">=0.3.2"}


### PR DESCRIPTION
To use `-dev` environments on OS X, I found it necessary to move the dev dependencies to a pixi feature. This moves us towards defining everything in the environments in a common way anyway, which is a good thing. 