### PR TITLE
fix: make sure we don't load hydrogens or impute missing atoms in RSCC script.

### DIFF
--- a/scripts/eval/rscc_grid_search_script.py
+++ b/scripts/eval/rscc_grid_search_script.py
@@ -134,7 +134,9 @@ def process_group(
                 f"Could not find reference structure for occupancy {trials[0].altloc_occupancies}"
             )
         # parse() returns only the first altloc.
-        ref_structure = parse(ref_path, ccd_mirror_path=None)
+        ref_structure = parse(
+            ref_path, ccd_mirror_path=None, hydrogen_policy="remove", add_missing_atoms=False
+        )
         ref_atom_array = get_asym_unit_from_structure(ref_structure)
         ref_atom_array = remove_atoms_with_any_nan_coords(ref_atom_array)
     except (FileNotFoundError, OSError, ValueError, RuntimeError, AttributeError, TypeError) as e:
@@ -156,8 +158,16 @@ def process_group(
 
     # parse refined, align, and compute density once per trial.
     for trial in trials:
+        logger.info(
+            f"Processing trial for protein {trial.protein} occupancies {trial.altloc_occupancies}"
+        )
         try:
-            structure = parse(trial.refined_cif_path, ccd_mirror_path=None)
+            structure = parse(
+                trial.refined_cif_path,
+                ccd_mirror_path=None,
+                hydrogen_policy="remove",
+                add_missing_atoms=False
+            )
             atom_array = get_asym_unit_from_structure(structure)
             if not hasattr(atom_array, "coord") or atom_array.coord is None:
                 raise AttributeError("AtomArray | AtomArrayStack is missing coordinates")


### PR DESCRIPTION
This change restores the `hydrogen_policy="remove", add_missing_atoms=False` arguments to `atomworks.io.parse` calls, consistent with the Stacks paper. This is necessary to get the correct results out of the RSCC script, as it fails badly or gives inaccurate results if we compute metrics using NaN coordinate inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structure parsing by consistently removing hydrogens and preventing automatic addition of missing atoms.
  * Adjusted trial-processing logs to appear before refined-structure parsing for clearer progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->