### PR TITLE
fix(docker): remove stray line that fails Dockerfile.astera parsing

### DIFF
--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -57,7 +57,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # that the download cache no longer survives a pod restart — environments
 # themselves live in the synced checkout and are unaffected.
 RUN mkdir -p /var/cache/pixi
-    SAMPLEWORKS_SKIP_ENV_PREPARE=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \


### PR DESCRIPTION
## Summary

#369 left a dangling `SAMPLEWORKS_SKIP_ENV_PREPARE=1` after `RUN mkdir -p /var/cache/pixi` in `Dockerfile.astera`. Not an instruction, so the Astera image job dies at parse time:

```
dockerfile parse error on line 60: unknown instruction: SAMPLEWORKS_SKIP_ENV_PREPARE=1
```

The ENV block at the top already sets the variable; this deletes the stray line, nothing else.

## Why it only surfaced now

Masked until #397 merged: the dead skopeo digest failed `sync_checkpoints` first on every push since 08-24, so the Astera job was always skipped. Today's run for 07fb65d got past `sync_checkpoints` (public image built and pushed fine) and hit this instead. So the last Harbor `pixi-with-checkpoints` push is still `sha-177f948` (08-21).

## Gap worth closing (follow-up, not in this PR)

`docker-validate.yml` says it validates Dockerfile breakage on PRs, but its build step is `file: Dockerfile` — `Dockerfile.astera` is in the `paths:` trigger and never actually parsed. A `docker buildx build --call=check -f Dockerfile.astera` step (base pinned to `scratch` via build-arg) would have caught #369 at PR time; I didn't add it here because I couldn't verify `--call=check`'s warning-vs-error exit behavior locally.

## Testing

Line-level Dockerfile parse check (instructions/continuations/heredocs): fixed file clean, `main`'s file flags exactly line 60. The real proof is the `docker.yml` run after merge — the Astera job takes ~25 min when it works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Astera container configuration to enable standard environment preparation during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->