### PR TITLE
Enabling ext by default

### DIFF
--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -84,7 +84,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && install -m 0755 /app/run_experiments.sh /usr/local/bin/run_experiments.sh \
     && install -m 0755 /app/run_all_models.sh /usr/local/bin/run_all_models.sh \
     && for cmd in \
-        bash column csh curl dig emacs git htop nano ncdu ping rsync tini tmux vim wget zsh; do \
+        bash column csh curl dig emacs git htop nano ncdu ping rsync timeout tini tmux vim wget zsh; do \
           command -v "${cmd}" >/dev/null 2>&1 || exit 1; \
         done
 

--- a/docker/astera/install-ext-shell-hooks.sh
+++ b/docker/astera/install-ext-shell-hooks.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 profile_script="/etc/profile.d/sampleworks-ext-shell.sh"
-profile_comment="# Sampleworks: enter ext when ACTL sets EXT_SHELL=1."
+profile_comment="# Sampleworks: enter ext by default; EXT_SHELL=0 opts out."
 profile_line="[ -r ${profile_script} ] && . ${profile_script}"
 
 touch /root/.bashrc /home/dev/.bashrc

--- a/docker/astera/sampleworks-ext-shell.sh
+++ b/docker/astera/sampleworks-ext-shell.sh
@@ -1,5 +1,5 @@
-# Enter ext only when ACTL sets EXT_SHELL=1.
-[ "${EXT_SHELL:-}" = "1" ] || return 0 2>/dev/null || exit 0
+# Enter ext by default. Set EXT_SHELL=0 before shell start to opt out.
+[ "${EXT_SHELL:-1}" != "0" ] || return 0 2>/dev/null || exit 0
 
 case "$-" in
   *i*) ;;
@@ -12,7 +12,9 @@ esac
 [ -z "${EXT_SHELL_ACTIVE:-}" ] || return 0 2>/dev/null || exit 0
 [ -z "${BASH_EXECUTION_STRING:-}" ] || return 0 2>/dev/null || exit 0
 [ -z "${ZSH_EXECUTION_STRING:-}" ] || return 0 2>/dev/null || exit 0
-command -v ext >/dev/null 2>&1 || return 0 2>/dev/null || exit 0
+# Not just "is ext on PATH" but "does ext actually run" - past this point the
+# shell is handed over with exec, so a broken binary would end the session.
+ext --help >/dev/null 2>&1 || return 0 2>/dev/null || exit 0
 
 __sampleworks_ext_config_template="/usr/local/share/sampleworks/astera/ext-config.toml"
 __sampleworks_ext_data_home="${XDG_DATA_HOME:-${HOME:-/home/dev}/.local/share}"

--- a/docker/astera/sampleworks-ext-shell.sh
+++ b/docker/astera/sampleworks-ext-shell.sh
@@ -14,7 +14,11 @@ esac
 [ -z "${ZSH_EXECUTION_STRING:-}" ] || return 0 2>/dev/null || exit 0
 # Not just "is ext on PATH" but "does ext actually run" - past this point the
 # shell is handed over with exec, so a broken binary would end the session.
-ext --help >/dev/null 2>&1 || return 0 2>/dev/null || exit 0
+# Bounded because this runs synchronously during shell startup: an ext that
+# hangs must not hold the prompt hostage. timeout is coreutils and asserted
+# at build time in Dockerfile.astera; were it ever missing, this line just
+# fails and the shell stays plain, which is the safe direction.
+timeout 5 ext --help >/dev/null 2>&1 || return 0 2>/dev/null || exit 0
 
 __sampleworks_ext_config_template="/usr/local/share/sampleworks/astera/ext-config.toml"
 __sampleworks_ext_data_home="${XDG_DATA_HOME:-${HOME:-/home/dev}/.local/share}"


### PR DESCRIPTION
| Failure mode | command -v ext | ext --help |
|:---|:---|:---|
| not installed at all | catches | catches (127) |
| present, no execute bit | misses | catches (126) |
| missing shared lib / wrong arch | misses | catches (126/127) |
| segfaults on startup | misses | catches (139) |
| ext's own flag parsing broken | misses | catches (2) |
| --help ok, `ext shell` fails (auth/config) | misses | misses |
| hangs instead of exiting | misses | misses (stalls startup) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `ext` shell now starts automatically by default.
  - Set `EXT_SHELL=0` before starting the shell to opt out.
- **Bug Fixes**
  - Improved validation ensures the `ext` command is functional before handing over the shell, preventing startup issues when the command is unavailable or broken.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->