### PR TITLE
feat(rewards): prepare() takes RewardInputs, not an atom array

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,7 +454,7 @@ if reconciler.has_mismatch:
     aligned_coords, transform = reconciler.align(model_coords, reference_coords)
 ```
 
-Build reward inputs from the model atom array (not the input structure) when a mismatch exists. See `eval/structure_utils.py::SampleworksProcessedStructure.to_reward_inputs()` for the canonical pattern.
+Build reward inputs from the model atom array (not the input structure) when a mismatch exists. See `eval/structure_utils.py::SampleworksProcessedStructure.to_reward_inputs()` for the canonical pattern. Two-phase rewards (`PreparableRewardFunctionProtocol`) are prepared with those same `RewardInputs`, never with an atom array; `RewardInputs.to_atom_array()` rebuilds a reference `AtomArray` (model topology, reconciled coordinates and B-factors) for forward models that need one. Do not write reconciled values back into the model atom array.
 
 ## Avoiding Technical Debt
 

--- a/src/sampleworks/core/rewards/protocol.py
+++ b/src/sampleworks/core/rewards/protocol.py
@@ -26,12 +26,20 @@ class RewardInputs:
     all coordinates finite and all occupancies non-negative.  Wrappers are
     responsible for ensuring this (e.g. replacing NaN coordinates with
     noise and setting occupancy to 1.0 for model-operated atoms).
+
+    ``atom_array`` is the topology the tensors follow: the array they were built
+    from, kept for its per-atom identity (chain, residue, atom name, element,
+    altloc). It is never mutated, and its own ``coord``, ``b_factor`` and
+    ``occupancy`` are not authoritative; the tensors are. :meth:`to_atom_array`
+    combines the two for a forward model that needs an ``AtomArray`` (see
+    :class:`PreparableRewardFunctionProtocol`).
     """
 
     elements: Int[torch.Tensor, "*batch n_atoms"]
     b_factors: Float[torch.Tensor, "*batch n_atoms"]
     occupancies: Float[torch.Tensor, "*batch n_atoms"]
     input_coords: Float[torch.Tensor, "*batch n_atoms 3"]
+    atom_array: AtomArray | None = None
 
     @classmethod
     def from_atom_array(
@@ -62,7 +70,9 @@ class RewardInputs:
         Returns
         -------
         RewardInputs
-            Dataclass containing all inputs needed for reward function computation.
+            Dataclass containing all inputs needed for reward function computation,
+            with ``atom_array`` set to the topology they were built from (the first
+            model of an ``AtomArrayStack``).
         """
         # input validation: ensure atom_array has required annotations and valid values
         if not hasattr(atom_array, "element"):
@@ -128,12 +138,84 @@ class RewardInputs:
         if isinstance(device, str):
             device = torch.device(device)
 
+        # Keep the topology the tensors follow. A stack shares one topology across
+        # its models, so its first model stands for it.
+        from biotite.structure import AtomArrayStack
+
+        topology = atom_array[0] if isinstance(atom_array, AtomArrayStack) else atom_array
+
         return cls(
             elements=elements.to(device),
             b_factors=b_factors.to(device),
             occupancies=occupancies.to(device),
             input_coords=input_coords.to(device),
+            atom_array=topology,
         )
+
+    def to_atom_array(self, template: AtomArray | None = None) -> AtomArray:
+        """Build the single-conformer reference atom array these inputs describe.
+
+        For a reward's ``prepare()``. A forward model that fixes its topology up
+        front (SFcalculator, for one) needs an ``AtomArray`` carrying the model
+        atom identities *and* the reconciled reference coordinates and B-factors
+        that ``__call__`` will see, not the model template's placeholders.
+        SFcalculator estimates the solvent fraction from atom positions at
+        construction, so the coordinates matter there.
+
+        Coordinates and B-factors are taken from batch element 0; the pipeline
+        builds them identical across the batch. Occupancy is set to 1.0 for every
+        atom because this is a topology, not an ensemble.
+
+        Parameters
+        ----------
+        template
+            Atom array supplying the topology. Defaults to ``self.atom_array``.
+            Copied, never mutated.
+
+        Returns
+        -------
+        AtomArray
+            Copy of the template with ``coord``, ``b_factor`` and ``occupancy``
+            overwritten from these inputs.
+
+        Raises
+        ------
+        ValueError
+            If no template is available, or its atom count differs from these
+            inputs.
+        """
+        if template is None:
+            template = self.atom_array
+        if template is None:
+            raise ValueError(
+                "These RewardInputs carry no atom array; pass `template` or build them with "
+                "RewardInputs.from_atom_array."
+            )
+        n_atoms = self.b_factors.shape[-1]
+        if template.array_length() != n_atoms:
+            raise ValueError(
+                f"template has {template.array_length()} atoms, but these RewardInputs "
+                f"describe {n_atoms}; pass the atom array the inputs were built from."
+            )
+
+        atom_array = template.copy()
+        # Biotite annotations are numpy: collapse the leading batch dims, take element 0,
+        # and move to CPU (`np.asarray` inside `set_annotation` raises for CUDA tensors).
+        atom_array.coord = (
+            self.input_coords.reshape(-1, n_atoms, 3)[0]
+            .detach()
+            .to(device="cpu", dtype=torch.float32)
+            .numpy()
+        )
+        atom_array.set_annotation(
+            "b_factor",
+            self.b_factors.reshape(-1, n_atoms)[0]
+            .detach()
+            .to(device="cpu", dtype=torch.float32)
+            .numpy(),
+        )
+        atom_array.set_annotation("occupancy", np.ones(n_atoms, dtype=np.float32))
+        return atom_array
 
 
 @runtime_checkable
@@ -190,30 +272,34 @@ class RewardFunctionProtocol(Protocol):
 
 @runtime_checkable
 class PreparableRewardFunctionProtocol(RewardFunctionProtocol, Protocol):
-    """Protocol for reward functions that must be bound to the model's atom array first.
+    """Protocol for reward functions that must be bound to their reward inputs first.
 
-    "Model" is the generative model. Its atom array
-    (``SampleworksProcessedStructure.reward_atom_array``) is the one the sampled
-    coordinates follow, and it can differ from the processed input structure: the
-    model may add, drop or reorder atoms relative to the deposited file (see
-    ``utils/atom_reconciler.py``). A reward whose forward model depends on the atom
-    ordering itself — element symbols, residue identity, a unit cell — therefore
-    cannot be fully built from the input file. Such rewards are constructed in two
-    phases: ``__init__`` takes the up-front configuration, and :meth:`prepare`
-    binds the reward to the model atom array once sampling knows it.
+    A reward whose forward model depends on the atom ordering itself — element
+    symbols, residue identity, a unit cell — cannot be fully built from the input
+    file: the generative model may add, drop or reorder atoms relative to the
+    deposited structure (see ``utils/atom_reconciler.py``). Such rewards are
+    constructed in two phases: ``__init__`` takes the up-front configuration, and
+    :meth:`prepare` binds the reward to the :class:`RewardInputs` once sampling has
+    built them. Those are the same inputs every subsequent ``__call__`` is fed, so
+    what the reward is prepared against and what it scores cannot diverge. Their
+    ``atom_array`` carries the model topology; :meth:`RewardInputs.to_atom_array`
+    rebuilds a reference ``AtomArray`` (model identities, reconciled coordinates
+    and B-factors) for forward models that need one.
     """
 
-    def prepare(self, atom_array: AtomArray, *, device: torch.device | str = "cpu") -> None:
-        """Bind this reward to the model atom ordering.
+    def prepare(self, reward_inputs: RewardInputs, *, device: torch.device | str = "cpu") -> None:
+        """Bind this reward to the inputs its ``__call__`` will receive.
 
         Mutates the reward in place and returns nothing. Implementations must be
-        re-runnable, so a caller can prepare the same reward again for a different
-        atom array or device.
+        re-runnable, so a caller can prepare the same reward again for different
+        inputs or a different device, and must not write to ``reward_inputs`` or
+        its ``atom_array``.
 
         Parameters
         ----------
-        atom_array
-            Model-order atom array the subsequent ``__call__`` coordinates follow.
+        reward_inputs
+            Inputs built for the sampled coordinates (model atom space), as
+            returned by ``SampleworksProcessedStructure.to_reward_inputs``.
         device
             PyTorch device the prepared state is placed on.
         """
@@ -222,11 +308,11 @@ class PreparableRewardFunctionProtocol(RewardFunctionProtocol, Protocol):
 
 def prepare_reward_if_needed(
     reward: RewardFunctionProtocol,
-    atom_array: AtomArray,
+    reward_inputs: RewardInputs,
     *,
     device: torch.device | str = "cpu",
 ) -> None:
-    """Prepare ``reward`` against the model topology when it asks to be prepared.
+    """Prepare ``reward`` against ``reward_inputs`` when it asks to be prepared.
 
     Rewards that do not implement :class:`PreparableRewardFunctionProtocol` are
     left untouched, so callers can apply this unconditionally.
@@ -235,13 +321,14 @@ def prepare_reward_if_needed(
     ----------
     reward
         Reward function about to be used for guidance.
-    atom_array
-        Model-order atom array the reward's coordinates will follow.
+    reward_inputs
+        Inputs the reward's ``__call__`` will be fed; ``reward_inputs.atom_array``
+        is the model-order topology the coordinates follow.
     device
         PyTorch device the reward's prepared state is placed on.
     """
     if isinstance(reward, PreparableRewardFunctionProtocol):
-        reward.prepare(atom_array, device=device)
+        reward.prepare(reward_inputs, device=device)
 
 
 @runtime_checkable

--- a/src/sampleworks/core/rewards/structure_factor.py
+++ b/src/sampleworks/core/rewards/structure_factor.py
@@ -17,7 +17,7 @@ from SFC_Torch.io import PDBParser
 
 
 if TYPE_CHECKING:
-    from biotite.structure import AtomArray
+    from sampleworks.core.rewards.protocol import RewardInputs
 
 
 # Loss callable: maps (|Fcalc|, |Fobs|) over the masked reflections to a scalar.
@@ -294,8 +294,8 @@ class StructureFactorRewardFunction:
         # `List[str]` and swallows any failure into a misleading "columns not in the mtz" error.
         self.expcolumns = list(_resolve_expcolumns(expcolumns, self._mtz_dataset))
 
-    def prepare(self, atom_array: AtomArray, *, device: torch.device | str = "cpu") -> None:
-        """Build the SFcalculator from the model atom array, on ``device``.
+    def prepare(self, reward_inputs: RewardInputs, *, device: torch.device | str = "cpu") -> None:
+        """Build the SFcalculator from the reward inputs, on ``device``.
 
         Constructing the ``SFcalculator`` consumes the MTZ dataset parsed at
         ``__init__`` (no second file read) and populates the observed structure
@@ -303,10 +303,14 @@ class StructureFactorRewardFunction:
         bins, the outlier mask ``sfc.Outlier``, the R-free flags ``sfc.free_flag``,
         and the normalized ``|Eo|`` in ``sfc.Eo``.
 
-        Must be called once before the first ``__call__``, with the same atom
-        array that the sampled coordinates correspond to (model atom space:
-        ``model_atom_array or atom_array``). The atom ordering of ``atom_array``
+        Must be called once before the first ``__call__``, with the inputs built
+        for the sampled coordinates (model atom space); they are the same inputs
+        ``__call__`` is fed. The atom ordering of ``reward_inputs.atom_array``
         defines the column order of the coordinate tensor passed to ``__call__``.
+        The gemmi structure comes from :meth:`RewardInputs.to_atom_array`: the
+        model topology with the reconciled reference coordinates and B-factors,
+        not the model template's placeholders. That matters here because
+        ``inspect_data`` estimates the solvent fraction from the atom positions.
 
         This is also where the torch device is set, so pass the device the sampled
         coordinates will live on: every tensor built here (the SFcalculator internals and
@@ -320,11 +324,12 @@ class StructureFactorRewardFunction:
 
         Parameters
         ----------
-        atom_array
-            Biotite AtomArray for the atoms the model operates on. Needs
-            ``chain_id``, ``res_id``, ``res_name``, ``atom_name``, ``element``
-            annotations (its ``b_factor``/``occupancy`` are baked as defaults but
-            overridden each ``__call__``). A missing ``altloc_id`` is defaulted to
+        reward_inputs
+            Inputs for the atoms the model operates on, as returned by
+            ``SampleworksProcessedStructure.to_reward_inputs``. Their ``atom_array``
+            needs ``chain_id``, ``res_id``, ``res_name``, ``atom_name``, ``element``
+            annotations; the B-factors and occupancies are baked as defaults but
+            overridden each ``__call__``. A missing ``altloc_id`` is defaulted to
             blank inside ``atomarray_to_gemmi``.
         device
             Torch device to build on. Defaults to CPU rather than auto-selecting a GPU:
@@ -338,10 +343,12 @@ class StructureFactorRewardFunction:
             ``normalize_amplitude`` is False the same condition only logs a warning,
             since it also implies no reflection was flagged as an outlier.
         ValueError
-            If no reflection survives the mask; see :meth:`_build_reflection_mask`.
+            If ``reward_inputs`` carry no atom array to take the topology from, or
+            if no reflection survives the mask; see :meth:`_build_reflection_mask`.
         """
         self.device = torch.device(device)
 
+        atom_array = reward_inputs.to_atom_array()
         gemmi_structure = atomarray_to_gemmi(
             atom_array,
             unit_cell=self.unit_cell,
@@ -518,8 +525,8 @@ class StructureFactorRewardFunction:
         """
         if self.sfc is None or self._reflection_mask is None:
             raise RuntimeError(
-                "StructureFactorRewardFunction.prepare() must be called with the model "
-                "atom array before the reward is evaluated."
+                "StructureFactorRewardFunction.prepare() must be called with the reward "
+                "inputs before the reward is evaluated."
             )
 
         # The topology (atom count included) is fixed by prepare(); a mismatch would otherwise
@@ -533,8 +540,8 @@ class StructureFactorRewardFunction:
             if n_atoms != n_topology_atoms:
                 raise ValueError(
                     f"{name} has {n_atoms} atoms but the SFcalculator topology built by "
-                    f"prepare() has {n_topology_atoms}. Call prepare() with the same atom array "
-                    "the sampled coordinates correspond to (model atom space)."
+                    f"prepare() has {n_topology_atoms}. Call prepare() with the reward inputs "
+                    "built for the sampled coordinates (model atom space)."
                 )
 
         # SFcalculator has no per-conformer (batch) occupancy/B axis, so these must be shared

--- a/src/sampleworks/core/scalers/fk_steering.py
+++ b/src/sampleworks/core/scalers/fk_steering.py
@@ -114,14 +114,11 @@ class FKSteering:
 
         reconciler = processed.reconciler.to(coords.device)
         reward_inputs = processed.to_reward_inputs(device=coords.device)
-        # `to_reward_inputs` neither mutates `processed` (a frozen dataclass) nor reconciles
-        # coordinates. It builds the reward tensors in model atom order and uses the reconciler's
-        # index maps only to copy the structure's B-factors onto the common atoms.
-        # `reward_atom_array` is that same model-order array, so the topology `prepare` binds to
-        # is the one the sampled coordinates follow. When the model exposes its own array, its
-        # `.coord` are the model's template coordinates, not the reconciled reference; that is
-        # `reward_inputs.input_coords`.
-        prepare_reward_if_needed(reward, processed.reward_atom_array, device=coords.device)
+        # Two-phase rewards are bound to the same inputs every step hands to `reward`: model
+        # atom order, the structure's B-factors on the common atoms, and the reconciled
+        # reference coordinates. `processed` (a frozen dataclass) and its atom arrays are
+        # never written to.
+        prepare_reward_if_needed(reward, reward_inputs, device=coords.device)
 
         schedule = sampler.compute_schedule(self.num_steps)
         loss_history: list[torch.Tensor] = []

--- a/src/sampleworks/core/scalers/pure_guidance.py
+++ b/src/sampleworks/core/scalers/pure_guidance.py
@@ -89,16 +89,11 @@ class PureGuidance:
 
         reconciler = processed_structure.reconciler.to(coords.device)
         reward_inputs = processed_structure.to_reward_inputs(device=coords.device)
-        # `to_reward_inputs` neither mutates `processed_structure` (a frozen dataclass) nor
-        # reconciles coordinates. It builds the reward tensors in model atom order and uses the
-        # reconciler's index maps only to copy the structure's B-factors onto the common atoms.
-        # `reward_atom_array` is that same model-order array, so the topology `prepare` binds to
-        # is the one the sampled coordinates follow. When the model exposes its own array, its
-        # `.coord` are the model's template coordinates, not the reconciled reference; that is
-        # `reward_inputs.input_coords`.
-        prepare_reward_if_needed(
-            reward, processed_structure.reward_atom_array, device=coords.device
-        )
+        # Two-phase rewards are bound to the same inputs every step hands to `reward`: model
+        # atom order, the structure's B-factors on the common atoms, and the reconciled
+        # reference coordinates. `processed_structure` (a frozen dataclass) and its atom
+        # arrays are never written to.
+        prepare_reward_if_needed(reward, reward_inputs, device=coords.device)
 
         trajectory_denoised: list[torch.Tensor] = []
         trajectory_next_step: list[torch.Tensor] = []

--- a/src/sampleworks/eval/structure_utils.py
+++ b/src/sampleworks/eval/structure_utils.py
@@ -75,6 +75,9 @@ class SampleworksProcessedStructure:
         Reward tensors are generated from the model atom array whenever possible.
         Structure-derived B-factors are copied onto common atoms, and the
         reference coordinates come from ``self.input_coords`` (model-space).
+        The result keeps :attr:`reward_atom_array` as its topology
+        (``RewardInputs.atom_array``), untouched. A two-phase reward's ``prepare``
+        receives these same inputs; see ``prepare_reward_if_needed``.
 
         Parameters
         ----------

--- a/tests/integration/test_mismatch_integration.py
+++ b/tests/integration/test_mismatch_integration.py
@@ -701,6 +701,54 @@ class TestPreprocessingPipeline:
             expected_common_b_factors,
         )
 
+    def test_to_atom_array_has_model_topology_and_reconciled_values(
+        self, mismatch_case: MismatchCase
+    ):
+        """The array a reward's ``prepare()`` rebuilds combines both sides of the mismatch.
+
+        Topology comes from the model atom array, coordinates and B-factors from the reward
+        inputs (the structure's values on common atoms, see ``test_b_factor_override``), and
+        occupancy from neither. The model atom array itself is read, never written.
+        """
+        struct_atom_array = mismatch_case.struct_atom_array.copy()
+        struct_atom_array.set_annotation(
+            "b_factor", np.linspace(5.0, 35.0, mismatch_case.n_struct, dtype=np.float32)
+        )
+        case = MismatchCase(
+            id=mismatch_case.id,
+            description=mismatch_case.description,
+            model_atom_array=mismatch_case.model_atom_array.copy(),
+            struct_atom_array=struct_atom_array,
+            expected_n_common=mismatch_case.expected_n_common,
+            expected_has_mismatch=mismatch_case.expected_has_mismatch,
+        )
+        structure = {"asym_unit": struct_atom_array.copy(), "metadata": {"id": case.id}}
+
+        processed, _ = _preprocess(MismatchCaseWrapper(case), structure)
+        reward_inputs = processed.to_reward_inputs(device="cpu")
+        assert reward_inputs.atom_array is processed.reward_atom_array
+        template_b_factors = processed.reward_atom_array.b_factor.copy()
+        template_coords = processed.reward_atom_array.coord.copy()
+        assert not np.allclose(template_b_factors, reward_inputs.b_factors[0].numpy()), (
+            "setup failed to make the template and the reward inputs disagree"
+        )
+
+        prepared = reward_inputs.to_atom_array()
+
+        assert prepared.array_length() == mismatch_case.n_model
+        for category in ["atom_name", "res_id", "chain_id", "element"]:
+            np.testing.assert_array_equal(
+                prepared.get_annotation(category),
+                mismatch_case.model_atom_array.get_annotation(category),
+                err_msg=f"annotation {category!r} should come from the model atom array",
+            )
+        np.testing.assert_allclose(prepared.coord, reward_inputs.input_coords[0].numpy())
+        np.testing.assert_allclose(prepared.b_factor, reward_inputs.b_factors[0].numpy())
+        np.testing.assert_allclose(prepared.occupancy, np.ones(mismatch_case.n_model))
+        # The model atom array is left as it was: nothing is written back into it.
+        np.testing.assert_array_equal(processed.reward_atom_array.b_factor, template_b_factors)
+        np.testing.assert_array_equal(processed.reward_atom_array.coord, template_coords)
+
 
 class TestSamplerStep:
     """EDM sampler mismatch behavior with coordinate level checks."""

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -600,11 +600,12 @@ class TestTrajectoryScalerMatrixMock:
         trajectory_scaler_type: TrajectoryScalers,
         device: torch.device,
     ):
-        """Two-phase rewards see the model atom array before any reward evaluation.
+        """Two-phase rewards are prepared with model-topology reward inputs before any evaluation.
 
         The model and the structure deliberately have different atom counts. A reward
         prepared against the input structure would bind the wrong atom ordering, which
-        is how the structure-factor reward silently scores the wrong thing.
+        is how the structure-factor reward silently scores the wrong thing. The inputs
+        handed to ``prepare`` carry the model atom array as their topology.
         """
 
         struct_atom_array = build_test_atom_array(
@@ -645,6 +646,10 @@ class TestTrajectoryScalerMatrixMock:
         )
 
         assert reward.prepared_atom_counts == [case.n_model]
+        (prepared,) = reward.prepared_inputs
+        assert prepared.atom_array is not None
+        assert prepared.atom_array.array_length() == case.n_model
+        assert list(prepared.atom_array.atom_name) == list(case.model_atom_array.atom_name)
         assert reward.calls > 0
         assert reward.calls_before_prepare == 0
 

--- a/tests/mocks/rewards.py
+++ b/tests/mocks/rewards.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import torch
-from biotite.structure import AtomArray
+from sampleworks.core.rewards.protocol import RewardInputs
 from torch import Tensor
 
 
@@ -35,8 +35,9 @@ class MockPreparableRewardFunction(MockGradientRewardFunction):
 
     Scores exactly like :class:`MockGradientRewardFunction` and adds ``prepare``, so
     it satisfies ``PreparableRewardFunctionProtocol``. Preparation changes nothing
-    about the score; the point is the record, so tests can assert which atom array
-    and device the scalers handed over and that no evaluation preceded ``prepare``.
+    about the score; the point is the record, so tests can assert which reward
+    inputs and device the scalers handed over and that no evaluation preceded
+    ``prepare``.
     """
 
     def __init__(self, gradient_scale: float = 1.0):
@@ -49,25 +50,27 @@ class MockPreparableRewardFunction(MockGradientRewardFunction):
         """
         super().__init__(gradient_scale)
         self.prepared_with: list[tuple[int, str]] = []
+        self.prepared_inputs: list[RewardInputs] = []
         self.calls = 0
         self.calls_before_prepare = 0
 
     @property
     def prepared_atom_counts(self) -> list[int]:
-        """Atom count of every array this reward was prepared against, in order."""
+        """Atom count of every reward input this reward was prepared against, in order."""
         return [n_atoms for n_atoms, _ in self.prepared_with]
 
-    def prepare(self, atom_array: AtomArray, *, device: torch.device | str = "cpu") -> None:
-        """Record the atom count and device this reward was bound to.
+    def prepare(self, reward_inputs: RewardInputs, *, device: torch.device | str = "cpu") -> None:
+        """Record the reward inputs (by object and atom count) and device this reward was bound to.
 
         Parameters
         ----------
-        atom_array
-            Model-order atom array the caller is binding the reward to.
+        reward_inputs
+            Model-order reward inputs the caller is binding the reward to.
         device
             Device the prepared state would be placed on.
         """
-        self.prepared_with.append((atom_array.array_length(), str(device)))
+        self.prepared_with.append((reward_inputs.b_factors.shape[-1], str(device)))
+        self.prepared_inputs.append(reward_inputs)
 
     def __call__(self, coordinates: Tensor, *args: Any, **kwargs: Any) -> Tensor:
         """Score as the parent does, counting evaluations and any that precede ``prepare``.

--- a/tests/rewards/conftest.py
+++ b/tests/rewards/conftest.py
@@ -183,6 +183,7 @@ def reward_function_1vme_sf(
     device: torch.device,
 ) -> "StructureFactorRewardFunction":
     """Structure factor reward (|Fprotein| only) prepared using the 1vme structure's topology."""
+    from sampleworks.core.rewards.protocol import RewardInputs
     from sampleworks.core.rewards.structure_factor import StructureFactorRewardFunction
 
     # normalize_amplitude=True scores normalized E-values (|Ec| vs sfc.Eo), which are
@@ -192,5 +193,8 @@ def reward_function_1vme_sf(
         expcolumns=["Fprotein", "SIGFprotein"],
         normalize_amplitude=True,
     )
-    reward_function.prepare(structure_1vme_sf, device=device)
+    reward_function.prepare(
+        RewardInputs.from_atom_array(structure_1vme_sf, ensemble_size=1, device=device),
+        device=device,
+    )
     return reward_function

--- a/tests/rewards/test_prepare_hook.py
+++ b/tests/rewards/test_prepare_hook.py
@@ -5,10 +5,16 @@ from sampleworks.core.rewards.protocol import (
     PreparableRewardFunctionProtocol,
     prepare_reward_if_needed,
     RewardFunctionProtocol,
+    RewardInputs,
 )
 
 from tests.mocks import MockGradientRewardFunction, MockPreparableRewardFunction
 from tests.utils.atom_array_builders import build_test_atom_array
+
+
+def _inputs(n_atoms: int) -> RewardInputs:
+    """Single-conformer reward inputs over ``n_atoms`` test atoms."""
+    return RewardInputs.from_atom_array(build_test_atom_array(n_atoms=n_atoms), ensemble_size=1)
 
 
 def test_preparable_reward_satisfies_both_protocols():
@@ -24,20 +30,24 @@ def test_plain_reward_is_not_preparable():
     assert not isinstance(MockGradientRewardFunction(), PreparableRewardFunctionProtocol)
 
 
-def test_prepare_hook_forwards_atom_array_and_device():
-    """The reward is bound to the atom array and device the caller passed."""
+def test_prepare_hook_forwards_reward_inputs_and_device():
+    """The reward is bound to the very reward inputs and device the caller passed."""
     reward = MockPreparableRewardFunction()
+    inputs = _inputs(7)
 
-    prepare_reward_if_needed(reward, build_test_atom_array(n_atoms=7), device=torch.device("cpu"))
+    prepare_reward_if_needed(reward, inputs, device=torch.device("cpu"))
 
     assert reward.prepared_with == [(7, "cpu")]
+    # The same object `__call__` will be fed, not a copy or a derived atom array.
+    assert reward.prepared_inputs == [inputs]
+    assert reward.prepared_inputs[0] is inputs
 
 
 def test_prepare_hook_is_a_no_op_for_rewards_that_do_not_need_it():
     """Callers can prepare unconditionally, so one-phase rewards must be untouched."""
     reward = MockGradientRewardFunction()
 
-    prepare_reward_if_needed(reward, build_test_atom_array(n_atoms=4), device="cpu")
+    prepare_reward_if_needed(reward, _inputs(4), device="cpu")
 
     # 0.5 * ||ones(1, 4, 3)||^2: the reward scores exactly as if the hook had never run.
     assert reward(torch.ones(1, 4, 3)) == 6.0
@@ -47,7 +57,7 @@ def test_prepare_is_rerunnable_for_a_new_topology():
     """Preparing again rebinds, so a reward can move between topologies or devices."""
     reward = MockPreparableRewardFunction()
 
-    prepare_reward_if_needed(reward, build_test_atom_array(n_atoms=3), device="cpu")
-    prepare_reward_if_needed(reward, build_test_atom_array(n_atoms=5), device="cpu")
+    prepare_reward_if_needed(reward, _inputs(3), device="cpu")
+    prepare_reward_if_needed(reward, _inputs(5), device="cpu")
 
     assert reward.prepared_with == [(3, "cpu"), (5, "cpu")]

--- a/tests/rewards/test_reward_inputs.py
+++ b/tests/rewards/test_reward_inputs.py
@@ -1,11 +1,17 @@
-"""Tests for RewardInputs validation.
+"""Tests for RewardInputs.
 
-Verifies that RewardInputs.from_atom_array rejects atom arrays with NaN
-B-factors, NaN coordinates, and invalid occupancies.
+``from_atom_array`` must reject atom arrays with NaN B-factors, NaN coordinates, and
+invalid occupancies, and keep the topology it was built from. ``to_atom_array`` must
+rebuild the reference array a reward's ``prepare()`` needs without touching that
+topology.
 """
+
+from dataclasses import replace
 
 import numpy as np
 import pytest
+import torch
+from biotite.structure import array, Atom, AtomArray, stack
 from sampleworks.core.rewards.protocol import RewardInputs
 
 
@@ -62,3 +68,164 @@ class TestRewardInputsFromAtomArray:
 
         with pytest.raises(ValueError, match="NaN coordinates"):
             RewardInputs.from_atom_array(atom_array, ensemble_size=1)
+
+
+@pytest.fixture
+def toy_atom_array() -> AtomArray:
+    """Four atoms in two residues, distinct coordinates and B-factors, fractional occupancies."""
+    atoms = [
+        Atom(
+            [1.0, 2.0, 3.0],
+            chain_id="A",
+            res_id=1,
+            res_name="GLY",
+            atom_name="N",
+            element="N",
+            b_factor=11.0,
+            occupancy=0.5,
+        ),
+        Atom(
+            [2.0, 3.0, 4.0],
+            chain_id="A",
+            res_id=1,
+            res_name="GLY",
+            atom_name="CA",
+            element="C",
+            b_factor=12.0,
+            occupancy=0.5,
+        ),
+        Atom(
+            [3.0, 4.0, 5.0],
+            chain_id="A",
+            res_id=2,
+            res_name="ALA",
+            atom_name="N",
+            element="N",
+            b_factor=13.0,
+            occupancy=1.0,
+        ),
+        Atom(
+            [4.0, 5.0, 6.0],
+            chain_id="A",
+            res_id=2,
+            res_name="ALA",
+            atom_name="CB",
+            element="C",
+            b_factor=14.0,
+            occupancy=0.25,
+        ),
+    ]
+    return array(atoms)
+
+
+class TestRewardInputsTopology:
+    """``from_atom_array`` keeps the atom array the tensors were built from."""
+
+    def test_topology_is_the_source_array(self, toy_atom_array):
+        """The stored topology is the very array passed in, not a copy."""
+        reward_inputs = RewardInputs.from_atom_array(toy_atom_array, ensemble_size=2)
+
+        assert reward_inputs.atom_array is toy_atom_array
+
+    def test_stack_input_keeps_its_first_model(self, toy_atom_array):
+        """An ``AtomArrayStack`` shares one topology, represented by its first model."""
+        reward_inputs = RewardInputs.from_atom_array(stack([toy_atom_array]), ensemble_size=1)
+
+        assert isinstance(reward_inputs.atom_array, AtomArray)
+        assert reward_inputs.atom_array.array_length() == toy_atom_array.array_length()
+
+    def test_tensor_only_construction_has_no_topology(self):
+        """Building the dataclass directly, as tests do, leaves ``atom_array`` unset."""
+        n_atoms = 3
+        reward_inputs = RewardInputs(
+            elements=torch.zeros(1, n_atoms, dtype=torch.long),
+            b_factors=torch.full((1, n_atoms), 20.0),
+            occupancies=torch.ones(1, n_atoms),
+            input_coords=torch.zeros(1, n_atoms, 3),
+        )
+
+        assert reward_inputs.atom_array is None
+
+
+class TestRewardInputsToAtomArray:
+    """Verify the reference atom array handed to a reward's ``prepare()``."""
+
+    @pytest.mark.parametrize("ensemble_size,num_particles", [(1, 1), (4, 1), (4, 2)])
+    def test_round_trip_preserves_coords_b_factors_and_topology(
+        self, ensemble_size, num_particles, toy_atom_array
+    ):
+        """``from_atom_array`` then ``to_atom_array`` returns the template's own values.
+
+        Occupancy is the exception: the result is a topology, so it is 1.0 everywhere,
+        whatever the template held.
+        """
+        reward_inputs = RewardInputs.from_atom_array(
+            toy_atom_array, ensemble_size=ensemble_size, num_particles=num_particles
+        )
+
+        result = reward_inputs.to_atom_array()
+
+        assert result is not toy_atom_array
+        np.testing.assert_allclose(result.coord, toy_atom_array.coord)
+        np.testing.assert_allclose(result.b_factor, toy_atom_array.b_factor)
+        np.testing.assert_allclose(result.occupancy, np.ones(toy_atom_array.array_length()))
+        for category in ["chain_id", "res_id", "res_name", "atom_name", "element"]:
+            np.testing.assert_array_equal(
+                result.get_annotation(category), toy_atom_array.get_annotation(category)
+            )
+        # The template is read, never written: its fractional occupancies survive.
+        np.testing.assert_allclose(toy_atom_array.occupancy, [0.5, 0.5, 1.0, 0.25])
+
+    def test_reconciled_values_override_the_template(self, toy_atom_array):
+        """Coordinates and B-factors come from the tensors, as ``to_reward_inputs`` sets them.
+
+        This is the handoff that matters for ``prepare()``: a model template's placeholder
+        B-factors and coordinates must not reach a forward model built from this array.
+        """
+        n_atoms = toy_atom_array.array_length()
+        reward_inputs = RewardInputs.from_atom_array(toy_atom_array, ensemble_size=2)
+        new_b_factors = torch.arange(n_atoms, dtype=torch.float32) + 100.0
+        new_coords = torch.arange(n_atoms * 3, dtype=torch.float32).reshape(n_atoms, 3) - 50.0
+        reconciled = replace(
+            reward_inputs,
+            b_factors=new_b_factors.expand(2, -1),
+            input_coords=new_coords.expand(2, -1, -1),
+        )
+
+        result = reconciled.to_atom_array()
+
+        np.testing.assert_allclose(result.b_factor, new_b_factors.numpy())
+        np.testing.assert_allclose(result.coord, new_coords.numpy())
+        assert reconciled.atom_array is toy_atom_array
+        np.testing.assert_allclose(toy_atom_array.b_factor, [11.0, 12.0, 13.0, 14.0])
+
+    def test_explicit_template_overrides_the_stored_topology(self, toy_atom_array):
+        """A caller may supply the topology array instead of relying on the stored one."""
+        reward_inputs = RewardInputs.from_atom_array(toy_atom_array, ensemble_size=1)
+        template = toy_atom_array.copy()
+        template.set_annotation("atom_name", np.array(["X1", "X2", "X3", "X4"]))
+
+        result = reward_inputs.to_atom_array(template)
+
+        np.testing.assert_array_equal(result.atom_name, ["X1", "X2", "X3", "X4"])
+        np.testing.assert_allclose(result.coord, toy_atom_array.coord)
+
+    def test_template_atom_count_mismatch_raises(self, toy_atom_array):
+        """A template that does not describe these atoms is rejected."""
+        reward_inputs = RewardInputs.from_atom_array(toy_atom_array, ensemble_size=1)
+
+        with pytest.raises(ValueError, match="atoms"):
+            reward_inputs.to_atom_array(toy_atom_array[:2])
+
+    def test_without_any_topology_raises(self):
+        """Tensor-only inputs cannot produce an atom array unless a template is given."""
+        n_atoms = 4
+        reward_inputs = RewardInputs(
+            elements=torch.zeros(1, n_atoms, dtype=torch.long),
+            b_factors=torch.full((1, n_atoms), 20.0),
+            occupancies=torch.ones(1, n_atoms),
+            input_coords=torch.zeros(1, n_atoms, 3),
+        )
+
+        with pytest.raises(ValueError, match="no atom array"):
+            reward_inputs.to_atom_array()

--- a/tests/rewards/test_structure_factor_reward.py
+++ b/tests/rewards/test_structure_factor_reward.py
@@ -26,6 +26,7 @@ import reciprocalspaceship as rs
 import torch
 from biotite.structure import AtomArray
 from reciprocalspaceship.utils import add_rfree
+from sampleworks.core.rewards.protocol import RewardInputs
 from sampleworks.core.rewards.structure_factor import (
     _MIN_RETAINED_REFLECTION_FRACTION,
     _MIN_RETAINED_REFLECTIONS,
@@ -46,9 +47,14 @@ def make_prepared_reward(mtz_path, atom_array, device: torch.device, **kwargs):
     ``gpu``. ``kwargs`` pass straight to the constructor (e.g. ``bulk_solvent``,
     ``normalize_amplitude``, ``exclude_free_reflections``, ``expcolumns``). The single fixed
     config lives in the ``reward_function_1vme_sf`` fixture; these tests need varied configs.
+
+    ``prepare()`` takes reward inputs, so the SFcalculator topology is ``atom_array`` wrapped as
+    single-conformer ``RewardInputs`` (the coordinates and B-factors are the array's own).
     """
     rf = StructureFactorRewardFunction(mtz_path, **kwargs)
-    rf.prepare(atom_array, device=device)
+    rf.prepare(
+        RewardInputs.from_atom_array(atom_array, ensemble_size=1, device=device), device=device
+    )
     return rf
 
 


### PR DESCRIPTION
## Summary

Follow-up to #373, from the 4 Sep rewards discussion with Marcus and Doris: `prepare` takes the
`RewardInputs` rather than an atom array, so a two-phase reward is prepared against exactly what
its `__call__` is later fed, and nothing is written back into the model atom array.

Why. `to_reward_inputs` reconciles the structure's B-factors and reference coordinates onto the
model atom order, but those values live only in the returned `RewardInputs`. The model atom array
keeps its template placeholders (Boltz: flat B = 20; RF3: noise on unresolved atoms), and nothing
writes the reconciled values back, deliberately. #373 prepared the SF reward from that array, so
the SFcalculator, and its solvent-fraction estimate, were built from placeholder coordinates.
Doris raised this on #373 on 15 Aug; the meeting settled on passing the inputs rather than
overwriting the array.

## Changes

`PreparableRewardFunctionProtocol.prepare(reward_inputs, *, device) -> None` and
`prepare_reward_if_needed(reward, reward_inputs, *, device)` in `core/rewards/protocol.py`. Both
trajectory scalers pass the `RewardInputs` they attach to the step context, right after
`to_reward_inputs` and before the denoising loop.

`RewardInputs` gains `atom_array`, the topology the tensors were built from (set by
`from_atom_array`; the first model for an `AtomArrayStack`; `None` when the dataclass is built
from bare tensors, as tests do), and `to_atom_array()`, which copies that topology and overwrites
`coord`, `b_factor` and `occupancy` from the tensors (occupancy 1.0: a topology, not an ensemble).
That is Doris's converter from `dm/reward-prepare-hook`, fed by the inputs themselves.
`StructureFactorRewardFunction.prepare` builds its gemmi structure from it. Nothing is written into
the model atom array or `SampleworksProcessedStructure`; `reward_atom_array` stays as the property
`to_reward_inputs` takes its topology from.

The two rewards queued behind this (#319, #372) disagree with the old signature anyway, so this
is the moment to settle it. #374 and #375 are updated to it (`CompositeReward.prepare`, the
build-integration test).

## Testing

`tests/rewards/test_prepare_hook.py`: the helper hands a two-phase reward the very
`RewardInputs` object and device it was given (identity, not a copy), leaves a one-phase reward
alone, and can be re-run to rebind.

`tests/rewards/test_reward_inputs.py`: `from_atom_array` keeps the source array (first model of a
stack); `to_atom_array` round-trips coordinates, B-factors and annotations, takes coordinates and
B-factors from the tensors when they differ from the template, sets occupancy to 1.0, leaves the
template untouched, and rejects a template with the wrong atom count or inputs with no topology.

`tests/integration/test_mismatch_integration.py`: on every mismatch case, the array
`to_atom_array` rebuilds has the model's annotations and the reward inputs' coordinates and
B-factors, and the model atom array is byte-for-byte what it was before.

`tests/integration/test_pipeline_integration.py`: both trajectory scalers prepare a recording
reward exactly once, before the first evaluation, with inputs whose topology is the model's
four-atom array (the structure has five).

The SF reward tests (`make_prepared_reward`, the `reward_function_1vme_sf` fixture) wrap their atom
array in single-conformer `RewardInputs`; the tests themselves are unchanged.

Local, `boltz-osx` env, on the #373 branch this was developed on: `pytest tests -m 'not slow and
not gpu'` → 929 passed, 31 skipped. The gpu-marked SF tests forced onto CPU: all 13 SF reward tests
(occupancy, every bulk-solvent mode, config) and the 16 structure-factor contract tests passed.
Ruff and ty clean on the changed files. Cherry-picked onto `main` after #373 merged; the trees
were identical, so the pick applied cleanly.

## Rollout

No new dependencies, no CLI or configuration changes, and no behavior change for any reward that
doesn't implement `prepare`. The `prepare` signature changes for #374 and #375, which already
carry it. Merge this before them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved reward preparation to preserve model atom topology while using reconciled coordinates and B-factors.
  * Added support for rebuilding a reference structure from reward inputs, including consistent occupancy values.
  * Updated structure-factor rewards and sampling workflows to use complete reward inputs for improved model/structure alignment.

* **Bug Fixes**
  * Added validation for missing topology and mismatched atom counts.
  * Ensured source model atom arrays remain unchanged during reward preparation.

* **Documentation**
  * Expanded guidance on handling atom-count mismatches and reward-input alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->